### PR TITLE
Changed sacct command line to capture all jobs

### DIFF
--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -41,7 +41,7 @@ CONFIG = {
             MAX_DAYS:          { 'required': False, type: 'int' },
           }
 
-COMMAND = 'sacct --allusers --parsable2 --format=JobID,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocCPUS,Nodelist --state=ca,cd,f,nf,to --starttime="%s" --endtime="%s"'
+COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobID,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocCPUS,Nodelist --state=ca,cd,f,nf,pr,rq,to --starttime="%s" --endtime="%s"'
 
 class SlurmBackend:
     """


### PR DESCRIPTION
This adds the --duplicates swithc and the pr state (preempted), which should work on all current Slurm versions. It also adds the "rq" state, which will work in the upcoming slurm 17.11.
All of these are needed to capture all jobs in the requested period.
