### PR TITLE
Changed sacct command line to capture all jobs

### DIFF
--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -41,7 +41,7 @@ CONFIG = {
             MAX_DAYS:          { 'required': False, type: 'int' },
           }
 
-COMMAND = 'sacct --allusers --parsable2 --format=JobID,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocCPUS,Nodelist --state=ca,cd,f,nf,to --starttime="%s" --endtime="%s"'
+COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobID,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocCPUS,Nodelist --state=ca,cd,f,nf,pr,rq,to --starttime="%s" --endtime="%s"'
 
 class SlurmBackend:
     """


### PR DESCRIPTION
Added --duplicates and the state pr, which should work with current slurm versions.  Also added the state rq, which will work with the upcoming slurm 17.11.
This is needed for the sacct command to capture all job runs ending in the given time period.