### PR TITLE
Generalize versioncmp

### DIFF
--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -63,13 +63,13 @@ def exec_cmd(cmd):
 def versioncmp(a, b):
     """
     return -1 if a < b, 0 if a = b, and +1 if a > b, where a and b are
-    version number strings of the format "X.Y.Z"
+    version number strings of the format "A.B.C[-D]" and A, B, C, D are numbers
     """
 
-    aa = [ int(x) for x in a.split('.') ]
-    bb = [ int(x) for x in b.split('.') ]
+    aa = [ int(x) for x in re.findall(r"\d+", a) ]
+    bb = [ int(x) for x in re.findall(r"\d+", b) ]
 
-    for i in range(3):
+    for i in range(min(len(aa), len(bb))):
         if aa[i] < bb[i]:
             return -1
         elif aa[i] > bb[i]:

--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -75,7 +75,8 @@ def versioncmp(a, b):
         elif aa[i] > bb[i]:
             return 1
 
-    return 0
+    ## If we get here, all common components are equal. Decide by the number of components:
+    return cmp(a_length, b_length)
 
 
 class SlurmBackend:


### PR DESCRIPTION
We had to generalize the versioncmp function in slurm.py to handle versions like 19.05.1-2. The suggested implementation should handle all combinations of a.b.c and e.f.g-h.