### PR TITLE
Added option for selecting billing unit (default: cpu)

### DIFF
--- a/docs/backend.slurm
+++ b/docs/backend.slurm
@@ -22,3 +22,9 @@ reuses the jobid.
 
 max_days: default=7
 Max number of days to process for every run of bart.
+
+billing_unit: default=cpu
+Which element of the AllocTRES should be used as the "number of cpus" in the
+reported job records.  If one sets up TRESBillingWeights in Slurm, using
+'billing_unit=billing' makes SGAS-BART report the same job "size" as Slurm
+uses for accounting.


### PR DESCRIPTION
I''ve added an option "billing_unit" to the [slurm] section of the config file, with a default value of "cpu". One can set it to any of the components of AllocTRES reported by sacct to change what unit is used for accounting. The default corresponds with the previous behaviour (using AllocCPUs). We needed this because we have set up billing units based on memory and gpu usage.

Hope you find the patch useful.