### PR TITLE
Switched from JobID to JobIDRaw in sacct.

### DIFF
--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -44,7 +44,7 @@ CONFIG = {
             BILLING_UNIT:      { 'required': False },
           }
 
-COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobID,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocTRES,Nodelist,NNodes --state=%s --starttime="%s" --endtime="%s"'
+COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobIDRaw,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocTRES,Nodelist,NNodes --state=%s --starttime="%s" --endtime="%s"'
 
 def exec_cmd(cmd):
     """


### PR DESCRIPTION
Switched from JobID to JobIDRaw in sacct.  Avoids problem with too long record file names.  This fixes #42 .