### PR TITLE
Changed sacct options to use "user" instead of "uid"

### DIFF
--- a/bart/slurm.py
+++ b/bart/slurm.py
@@ -17,7 +17,6 @@ import re
 
 from bart import config, common
 from bart.usagerecord import usagerecord
-from pwd import getpwuid
 
 SECTION = 'slurm'
 
@@ -57,7 +56,7 @@ CONFIG = {
             CHARGE_SCALE:      { 'required': False, type: 'float' },
           }
 
-COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobIDRaw,UID,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocTRES,Nodelist,NNodes --state=%s --starttime="%s" --endtime="%s"'
+COMMAND = 'sacct --allusers --duplicates --parsable2 --format=JobIDRaw,User,Partition,Submit,Start,End,Account,Elapsed,UserCPU,AllocTRES,Nodelist,NNodes --state=%s --starttime="%s" --endtime="%s"'
 
 def exec_cmd(cmd):
     """
@@ -238,7 +237,7 @@ class Slurm:
 
         # extract data from the workload trace (log_entry)
         job_id       = str(log_entry[0])
-        user_name    = getpwuid(int(log_entry[1]))[0]
+        user_name    = log_entry[1]
         queue        = log_entry[2]
         submit_time  = time.mktime(common.datetimeFromIsoStr(log_entry[3]).timetuple())
         start_time   = time.mktime(common.datetimeFromIsoStr(log_entry[4]).timetuple())


### PR DESCRIPTION
Currently, the sacct command in bart uses the "uid" field to get the user id of job owners, and the getpwuid() function to convert this to user name.  This patch changes this to use the sacct "user" field, which works even when the user does not exist in LDAP (because slurmdbd stores both uid and user name for jobs in the SQL DB).
